### PR TITLE
Put some platform-specific instructions under tabs

### DIFF
--- a/docs/guide/installation/installation-linux.md
+++ b/docs/guide/installation/installation-linux.md
@@ -4,22 +4,37 @@
 
 There are packages available for different distros:
 
-- [Arch](https://www.archlinux.org/packages/community/x86_64/flameshot/) `pacman -S flameshot`
+=== "Arch"
+    - Package: [flameshot](https://www.archlinux.org/packages/community/x86_64/flameshot/)
+    - Install: `pacman -S flameshot`
     - Snapshot also available via AUR: [flameshot-git](https://aur.archlinux.org/packages/flameshot-git).
 
-- [Debian 10+](https://tracker.debian.org/pkg/flameshot): `apt install flameshot`
+=== "Debian 10+"
+    - Package: [flameshot](https://tracker.debian.org/pkg/flameshot)
+    - Install: `apt install flameshot`
 
-- [Ubuntu 18.04+](https://launchpad.net/ubuntu/+source/flameshot): `apt install flameshot`
+=== "Ubuntu 18.04+"
+    - Package: [flameshot](https://launchpad.net/ubuntu/+source/flameshot)
+    - Install: `apt install flameshot`
 
-- [Fedora](https://src.fedoraproject.org/rpms/flameshot): `dnf install flameshot`
+=== "Fedora"
+    - Package: [flameshot](https://src.fedoraproject.org/rpms/flameshot)
+    - Install: `dnf install flameshot`
 
-- [NixOS](https://search.nixos.org/packages?query=flameshot): `nix-env -iA nixos.flameshot`
+=== "NixOS"
+    - Package: [flameshot](https://search.nixos.org/packages?query=flameshot)
+    - Install: `nix-env -iA nixos.flameshot`
 
-- [openSUSE](https://software.opensuse.org/package/flameshot)
+=== "openSUSE"
+    - Package: [flameshot](https://software.opensuse.org/package/flameshot)
 
-- [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/flameshot): `xbps-install flameshot`
+=== "Void Linux"
+    - Package: [flameshot](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/flameshot)
+    - Install: `xbps-install flameshot`
 
-- [Solus](https://dev.getsol.us/source/flameshot/): `eopkg install flameshot`
+=== "Solus"
+    - Package: [flameshot](https://dev.getsol.us/source/flameshot/)
+    - Install: `eopkg install flameshot`
 
 
 *Important things to Know:*
@@ -56,96 +71,93 @@ General packages(AppImage, snap, and Flatpak): they can run on common Linux-base
 
 ## Distro-Agnostic
 
-### AppImage
+=== "AppImage"
 
-You can always use the AppImage as it is distro agnostic:
+    You can always use the AppImage as it is distro agnostic:
 
-1. Navigate to the folder you would like to store the software (the following is a suggestion):
+    1. Navigate to the folder you would like to store the software (the following is a suggestion):
 
-```sh
-mkdir -p ~/Applications/Flameshot
-cd ~/Applications/Flameshot
-```
+    ```sh
+    mkdir -p ~/Applications/Flameshot
+    cd ~/Applications/Flameshot
+    ```
 
-2. Delete older versions of Flameshot AppImage:
+    2. Delete older versions of Flameshot AppImage:
 
-```sh
-rm Flameshot-*-x86_64.AppImage
-```
+    ```sh
+    rm Flameshot-*-x86_64.AppImage
+    ```
 
-3. Download the latest AppImage
-   2.1. Get it from [Release page](https://github.com/flameshot-org/flameshot/releases/latest)
-   OR
-   2.2. use the following to automatically download the latest.
+    3. Download the latest AppImage
+       2.1. Get it from [Release page](https://github.com/flameshot-org/flameshot/releases/latest)
+       OR
+       2.2. use the following to automatically download the latest.
 
-```sh
-curl -O -J -L $(curl -s https://api.github.com/repos/flameshot-org/flameshot/releases/latest \
-                | grep -Po 'https://github.com/flameshot-org/flameshot/releases/download/[^}]*\.AppImage' \
-                | uniq)
-```
+    ```sh
+    curl -O -J -L $(curl -s https://api.github.com/repos/flameshot-org/flameshot/releases/latest \
+                    | grep -Po 'https://github.com/flameshot-org/flameshot/releases/download/[^}]*\.AppImage' \
+                    | uniq)
+    ```
 
-4. Set it to executable:
+    4. Set it to executable:
 
-```sh
-chmod +x Flameshot-*-x86_64.AppImage
-```
+    ```sh
+    chmod +x Flameshot-*-x86_64.AppImage
+    ```
 
-5. Now you have the Flameshot ready and you can run the software:
+    5. Now you have the Flameshot ready and you can run the software:
 
-```sh
-./Flameshot-*-x86_64.AppImage
-```
+    ```sh
+    ./Flameshot-*-x86_64.AppImage
+    ```
 
-This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). You can now either:
+    This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). You can now either:
 
-6.1 click on the tray icon and select "Take screenshot"
+    6.1 click on the tray icon and select "Take screenshot"
 
-6.2 open terminal and use the following to run the application:
+    6.2 open terminal and use the following to run the application:
 
-```sh
-./Flameshot-*-x86_64.AppImage gui
-```
+    ```sh
+    ./Flameshot-*-x86_64.AppImage gui
+    ```
 
+=== "Snap"
 
-### Snap
+    Flameshot is not currently on snap, but when it gets available, you can install Flameshot through:
 
-Flameshot is not currently on snap, but when it gets available, you can install Flameshot through:
+    ```sh
+    snap install flameshot
+    ```
 
-```sh
-snap install flameshot
-```
+    to update the snap applications on your computer, you should run `snap refresh`.
 
-to update the snap applications on your computer, you should run `snap refresh`.
+=== "Flatpak"
 
+    Flameshot is not currently on Flathub, but it will be there soon and the information here will be updated accordingly. For now you can install the Flatpak from the github release:
 
-### Flatpak
+    ```sh
+    flatpak install flathub org.flameshot.Flameshot
+    ```
 
-Flameshot is not currently on Flathub, but it will be there soon and the information here will be updated accordingly. For now you can install the Flatpak from the github release:
+    Alternatively you can install from the github using Flatpak if you want a specific version. For example for getting the version 0.9.0:
 
-```sh
-flatpak install flathub org.flameshot.Flameshot
-```
+    ```sh
+    flatpak install https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/org.flameshot.Flameshot-0.9.0.x86_64.flatpak
+    ```
 
-Alternatively you can install from the github using Flatpak if you want a specific version. For example for getting the version 0.9.0:
+    And for runing it you should do
 
-```sh
-flatpak install https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/org.flameshot.Flameshot-0.9.0.x86_64.flatpak
-```
+    ```sh
+    flatpak run org.flameshot.Flameshot
+    ```
 
-And for runing it you should do
+    To update the flatpaks you can use `flatpak update`.
 
-```sh
-flatpak run org.flameshot.Flameshot
-```
+=== "Docker"
 
-To update the flatpaks you can use `flatpak update`.
+    There is also a docker image available for those who want (**not** maintained by Flameshot maintainers):
 
-
-### Docker
-
-There is also a docker image available for those who want (**not** maintained by Flameshot maintainers):
-
-https://github.com/ManuelLR/docker-flameshot
+    https://github.com/ManuelLR/docker-flameshot
 
 -------------------------------------------------
 

--- a/docs/guide/key-bindings.md
+++ b/docs/guide/key-bindings.md
@@ -19,63 +19,63 @@ These shortcuts are available in GUI mode:
 ### Global
 If you want use Flameshot as a default screenshot utility, chances are you want to launch it using the <kbd>Prt Sc</kbd> key. Flameshot doesn't yet offer a fully-automated option to do so, but you can configure your system to do so.
 
-#### On KDE Plasma desktop
-To make configuration easier, there's [a file](https://github.com/flameshot-org/flameshot/blob/master/docs/shortcuts-config/flameshot-shortcuts-kde) in the repository that more or less automates this process. This file will assign the following keys to the following actions by default:
+=== "KDE Plasma"
+    To make configuration easier, there's [a file](https://github.com/flameshot-org/flameshot/blob/master/docs/shortcuts-config/flameshot-shortcuts-kde) in the repository that more or less automates this process. This file will assign the following keys to the following actions by default:
 
-|  Keys                                                           |  Description                                                                                |
-|---                                                              |---                                                                                          |
-| <kbd>Prt Sc</kbd>                                               | Start the Flameshot screenshot tool and take a screenshot                                   |
-| <kbd>Ctrl</kbd> + <kbd>Prt Sc</kbd>                             | Wait for 3 seconds, then start the Flameshot screenshot tool and take a screenshot          |
-| <kbd>Shift</kbd> + <kbd>Prt Sc</kbd>                            | Take a full-screen (all monitors) screenshot and save it                                    |
-| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Prt Sc</kbd>          | Take a full-screen (all monitors) screenshot and copy it to the clipboard                   |
+    |  Keys                                                           |  Description                                                                                |
+    |---                                                              |---                                                                                          |
+    | <kbd>Prt Sc</kbd>                                               | Start the Flameshot screenshot tool and take a screenshot                                   |
+    | <kbd>Ctrl</kbd> + <kbd>Prt Sc</kbd>                             | Wait for 3 seconds, then start the Flameshot screenshot tool and take a screenshot          |
+    | <kbd>Shift</kbd> + <kbd>Prt Sc</kbd>                            | Take a full-screen (all monitors) screenshot and save it                                    |
+    | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Prt Sc</kbd>          | Take a full-screen (all monitors) screenshot and copy it to the clipboard                   |
 
-If you don't like the defaults, you can change them manually later.
+    If you don't like the defaults, you can change them manually later.
 
-Steps for using the configuration:
+    Steps for using the configuration:
 
-1. The configuration file configures shortcuts so that Flameshot automatically saves (without opening the save dialog) screenshots to _~/Pictures/Screenshots_ folder. Make sure you have that folder by running the following command:
+    1. The configuration file configures shortcuts so that Flameshot automatically saves (without opening the save dialog) screenshots to _~/Pictures/Screenshots_ folder. Make sure you have that folder by running the following command:
+        ```sh
+        mkdir -p ~/Pictures/Screenshots
+        ```
+       (If you don't like the default location, you can skip this step and configure your preferred directory later.)
+
+    2. Download the configuration file:
+        ```sh
+        cd ~/Desktop; wget https://raw.githubusercontent.com/flameshot-org/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde
+        ```
+    3. Go to _System Settings_ → _Shortcuts_ → _Custom Shortcuts_.
+    4. If there's one, you'll need to disable an entry for Spectacle, the default KDE screenshot utility first because its shortcuts might collide with Flameshot's ones; so, just uncheck the _Spectacle_ entry.
+    5. Click _Edit_ → _Import..._, navigate to the Desktop folder (or wherever you saved the configuration file) and open the configuration file.
+    6. Now the Flameshot entry should appear in the list. Click _Apply_ to apply the changes.
+    7. If you want to change the defaults, you can expand the entry, select the appropriate action and modify it as you wish; the process is pretty mush self-explanatory.
+
+=== "Ubuntu and Gnome based"
+
+    You can easily configure your 'print' keyboard shortcut to be assigned to Flameshot. Below an example to open Flameshot in GUI mode:
+
+    1. Open _Settings_ → _Devices_ → _Keyboard_  → _Shortcuts_.
+
+    2. Search for 'print', and unbind the screen capture function by selecting it, and clicking _backspace_.
+
+    3. Scroll down and click on the '+'.
+
+    4. On 'Name', name it 'Flameshot' or 'PrintScreen'.
+
+    5. Define the command as 'flameshot gui'.
+
+    6. Select 'Define shortcut...'and click your keyboard <kbd>Prt Sc</kbd> key.
+
+    Now you can use your default keyboard key to launch Flameshot.
+
+    For defining multiple shortcuts you can repeat the process above, and just change the command.
+
+    Some examples of commands are:
+
     ```sh
-    mkdir -p ~/Pictures/Screenshots
+    # Capture a region using the GUI, and have it automatically saved to your pictures folder when clicking the save button in GUI
+    flameshot gui -p /home/user/Pictures
+    # Capture the active monitor and save it automatically to your pictures folder
+    flameshot screen -p /home/user/Pictures
+    # Capture the full desktop (all monitors) and save it automatically to your pictures folder
+    flameshot full -p /home/user/Pictures
     ```
-   (If you don't like the default location, you can skip this step and configure your preferred directory later.)
-
-2. Download the configuration file:
-    ```sh
-    cd ~/Desktop; wget https://raw.githubusercontent.com/flameshot-org/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde
-    ```
-3. Go to _System Settings_ → _Shortcuts_ → _Custom Shortcuts_.
-4. If there's one, you'll need to disable an entry for Spectacle, the default KDE screenshot utility first because its shortcuts might collide with Flameshot's ones; so, just uncheck the _Spectacle_ entry.
-5. Click _Edit_ → _Import..._, navigate to the Desktop folder (or wherever you saved the configuration file) and open the configuration file.
-6. Now the Flameshot entry should appear in the list. Click _Apply_ to apply the changes.
-7. If you want to change the defaults, you can expand the entry, select the appropriate action and modify it as you wish; the process is pretty mush self-explanatory.
-
-#### On Ubuntu and other Gnome based distros
-
-You can easily configure your 'print' keyboard shortcut to be assigned to Flameshot. Below an example to open Flameshot in GUI mode:
-
-1. Open _Settings_ → _Devices_ → _Keyboard_  → _Shortcuts_.
-
-2. Search for 'print', and unbind the screen capture function by selecting it, and clicking _backspace_.
-
-3. Scroll down and click on the '+'.
-
-4. On 'Name', name it 'Flameshot' or 'PrintScreen'.
-
-5. Define the command as 'flameshot gui'.
-
-6. Select 'Define shortcut...'and click your keyboard <kbd>Prt Sc</kbd> key.
-
-Now you can use your default keyboard key to launch Flameshot.
-
-For defining multiple shortcuts you can repeat the process above, and just change the command.
-
-Some examples of commands are:
-
-```sh
-# Capture a region using the GUI, and have it automatically saved to your pictures folder when clicking the save button in GUI
-flameshot gui -p /home/user/Pictures
-# Capture the active monitor and save it automatically to your pictures folder
-flameshot screen -p /home/user/Pictures
-# Capture the full desktop (all monitors) and save it automatically to your pictures folder
-flameshot full -p /home/user/Pictures
-```


### PR DESCRIPTION
I had a minute, so I decided to de-clutter some pages using the pymdownx.tabbed
extension, already listed as a dependency in mkdocs.yml. I think this makes the
instructions more readable.
