### PR TITLE
Add nightly links

### DIFF
--- a/docs/guide/installation/installation-index.md
+++ b/docs/guide/installation/installation-index.md
@@ -6,6 +6,9 @@ Flameshot is a cross-platform software and can be installed on most operating sy
 - [macOS](/guide/installation/installation-osx)
 - [Windows](/guide/installation/installation-windows)
 
+!!! tip "Tip: Stay ahead of the curve"
+
+    If you want to run Flameshot with the most cutting edge features, you can
+    download a packaged development version from [here](/nightly).
+
 Alternatively, you can always compile from source. Click [here](/guide/installation/compilation) for instructions on how to compile from source on different operating systems.
-
-

--- a/docs/guide/installation/installation-linux.md
+++ b/docs/guide/installation/installation-linux.md
@@ -22,6 +22,11 @@ There are packages available for different distros:
 - [Solus](https://dev.getsol.us/source/flameshot/): `eopkg install flameshot`
 
 
+!!! tip "Tip: Stay ahead of the curve"
+
+    If you want to run Flameshot with the most cutting edge features, you can
+    download a development version from [here](/nightly).
+
 *Important things to Know:*
 
 1. Other than AUR (Arch user Repository), All packages listed above are maintained by the respective Linux distribution. Therefore, if the version is very old or you have problem installing Flameshot from the commands above, Please directly contact the distribution.

--- a/docs/guide/installation/installation-osx.md
+++ b/docs/guide/installation/installation-osx.md
@@ -12,3 +12,8 @@ You can install Flameshot on [macOS](https://en.wikipedia.org/wiki/MacOS) using 
     5. MacOS restricts applications from accessing the screen. Therefore you have to give Flameshot security permissions to "record" your desktop.
         ![A picture of the macOS Security & Privacy settings that shows the Flameshot should be added to the list in the "privacy" tab](/media/macos_permissions.png)
 
+!!! tip "Tip: Stay ahead of the curve"
+
+    If you want to run Flameshot with the most cutting edge features, you can
+    download a development version from [here](/nightly).
+

--- a/docs/guide/installation/installation-windows.md
+++ b/docs/guide/installation/installation-windows.md
@@ -3,6 +3,11 @@
 ## Manual installation
 - Hosted on [Github](https://github.com). [64-bit](https://github.com/flameshot-org/flameshot/releases), [32-bit](https://github.com/flameshot-org/flameshot/releases)
 
+!!! tip "Tip: Stay ahead of the curve"
+
+    If you want to run Flameshot with the most cutting edge features, you can
+    download a development version from [here](/nightly).
+
 
 ## Using package managers
 

--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -1,0 +1,14 @@
+# Nightly builds
+
+## Linux
+
+Download the latest development packages from [here](https://nightly.link/flameshot-org/flameshot/workflows/Linux-pack/master/Linux-distribution-artifact.zip).
+
+## MacOS
+
+Download the latest development packages from [here](https://nightly.link/flameshot-org/flameshot/workflows/MacOS-pack/master/MacOS-artifact.zip).
+
+## Windows
+
+Download the latest development packages from [here](https://nightly.link/flameshot-org/flameshot/workflows/Windows-pack/master/Windows-artifact.zip).
+


### PR DESCRIPTION
A lot of times in issues, we point the users to the master build to see if a problem is resolved. Some people don't know/want to compile from source, so we give them a link to the Github actions artifacts.

Well, I got fed up with having to go to GitHub actions, finding the target platform's workflow, copying the link, and then telling the users that they have to click on "Artifacts".

**The solution:**
This neat service: https://nightly.link/

It generates a link to the most recent artifact build on the master branch.

In the main **Installation** page and in the installation pages for each individual platform, I added a "Tip" bubble that tells the user they can download a development version of flameshot, with a link that points to [flameshot.org/nightly](https://flameshot.org/nightly). On this page users can download the build artifacts for each operating system.

Conveniently, this link is short, so we can quickly write it into our comments when we want to direct the users to this download page.

What do you think?