### PR TITLE
Update KDE shortcuts config links

### DIFF
--- a/docs/guide/key-bindings.md
+++ b/docs/guide/key-bindings.md
@@ -20,7 +20,7 @@ These shortcuts are available in GUI mode:
 If you want use Flameshot as a default screenshot utility, chances are you want to launch it using the <kbd>Prt Sc</kbd> key. Flameshot doesn't yet offer a fully-automated option to do so, but you can configure your system to do so.
 
 #### On KDE Plasma desktop
-To make configuration easier, there's [a file](https://github.com/flameshot-org/flameshot/blob/master/docs/shortcuts-config/flameshot-shortcuts-kde) in the repository that more or less automates this process. This file will assign the following keys to the following actions by default:
+To make configuration easier, there's [a file](https://github.com/flameshot-org/flameshot/blob/master/docs/shortcuts-config/flameshot-shortcuts-kde.khotkeys) in the repository that more or less automates this process. This file will assign the following keys to the following actions by default:
 
 |  Keys                                                           |  Description                                                                                |
 |---                                                              |---                                                                                          |
@@ -41,7 +41,7 @@ Steps for using the configuration:
 
 2. Download the configuration file:
     ```sh
-    cd ~/Desktop; wget https://raw.githubusercontent.com/flameshot-org/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde
+    cd ~/Desktop; wget https://raw.githubusercontent.com/flameshot-org/flameshot/master/docs/shortcuts-config/flameshot-shortcuts-kde.khotkeys
     ```
 3. Go to _System Settings_ → _Shortcuts_ → _Custom Shortcuts_.
 4. If there's one, you'll need to disable an entry for Spectacle, the default KDE screenshot utility first because its shortcuts might collide with Flameshot's ones; so, just uncheck the _Spectacle_ entry.


### PR DESCRIPTION
Hey! I noticed that the configuration file was renamed, but the old links remained on the site. I changed the links to the actual ones.