### PR TITLE
fix broken link, and styling the links in main docs

### DIFF
--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -41,7 +41,7 @@ There are packages available for different distros:
 
 
 If you want to run Flameshot with the most cutting edge features, you can
-download a development version from [here](/development-build).
+download a development version from [here](../development-build).
 
 
 *Important things to Know:*

--- a/sass/common/_global.scss
+++ b/sass/common/_global.scss
@@ -163,6 +163,9 @@ body {
 .docs-content {
   padding-bottom: 3rem;
   order: 1;
+  a {
+    text-decoration: underline;
+  }
 }
 
 .docs-navigation, .blog-navigation {

--- a/templates/index.html
+++ b/templates/index.html
@@ -168,7 +168,8 @@
             <h5 class="fs-3 text-dark mx-2 my-0"><strong>Linux Downloads</strong></h5>
             <p class="fs-6 text-dark mx-2 mt-2 mb-3">64-bit only, install via Appimage, your package manager, Snapcraft or Flathub</p>
             <div class="col-12 my-4 mx-auto">
-              <a class="btn btn-cta-solid btn-lg d-block d-md-inline-block m-2" href="https://github.com/flameshot-org/flameshot/releases/latest">Download Appimage</a>
+              <a class="btn btn-cta-solid btn-lg d-block d-md-inline-block m-2" href="https://github.com/flameshot-org/flameshot/releases/latest">Download AppImage</a>
+              <a class="btn btn-cta-solid btn-lg d-block d-md-inline-block m-2" href="/docs/installation/development-build">Download Nightly-builds Binaries</a>
             </div>
             <div class="col-12 my-5 mx-auto">
               <a href="https://snapcraft.io/flameshot"><img class="m-1" src="img/snapcraft.svg" title="Get it from the Snapcraft store" alt="get it from snapcraft store"></a>


### PR DESCRIPTION
- fixes #50 
- added a button for the nightly builds under the Linux tab on the index page
- added underline text decoration to the links in the main content of the docs section
