### PR TITLE
some minor styling for the inline code blocks

### DIFF
--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -32,7 +32,7 @@ There are packages available for different distros:
 
 - [NixOS](https://search.nixos.org/packages?query=flameshot): `nix-env -iA nixos.flameshot`
 
-- [openSUSE](https://software.opensuse.org/package/flameshot)
+- [openSUSE](https://software.opensuse.org/package/flameshot): `zypper install flameshot`
 
 - [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/flameshot): `xbps-install flameshot`
 

--- a/sass/components/_code.scss
+++ b/sass/components/_code.scss
@@ -14,6 +14,17 @@ code {
   border-radius: 1px;
 }
 
+p code {
+  border-radius: 4px;
+  background-color: #ffefef;
+}
+
+// li code {
+//  border-radius: 4px;
+//  background-color: #ffefef;
+// }
+
+
 pre {
   margin: 1.2rem 0;
 }


### PR DESCRIPTION
This still has the caveat that if the `<code>` is under the `<li>`  block it will not get this style. but the reason is that I couldn't manage to make the `li code {}` specific to `<li><code>blah blah</code></li>` and it was still getting applied to `<li><pre><code>blah blah</code></pre></li>`. Perhaps in some later versions we can fix this.