### PR TITLE
SCSS fix and typo corrected

### DIFF
--- a/content/docs/guide/faq.md
+++ b/content/docs/guide/faq.md
@@ -20,7 +20,7 @@ top = false
 
 Checkout our [keyboard shortcut page](../key-bindings) for more information.
 
-### On macOs Flameshot only captures a blank desktop
+### On macOS Flameshot only captures a blank desktop
 
 When running Flameshot on MacOs, you must grant it permission to screen record. See [troubleshooting](../troubleshooting#macos) for more information.
 

--- a/content/docs/installation/installation-osx.md
+++ b/content/docs/installation/installation-osx.md
@@ -1,5 +1,5 @@
 +++
-title = "Install on macOs"
+title = "Install on macOS"
 description = "Flameshot is a powerful yet simple to use screenshot software."
 date = 2021-05-01T08:00:00+00:00
 updated = 2021-05-01T08:00:00+00:00
@@ -9,7 +9,7 @@ sort_by = "weight"
 template = "docs/page.html"
 
 [extra]
-lead = 'How to install Flameshot on macOs.'
+lead = 'How to install Flameshot on macOS.'
 toc = true
 top = true
 +++

--- a/sass/components/_code.scss
+++ b/sass/components/_code.scss
@@ -14,15 +14,21 @@ code {
   border-radius: 1px;
 }
 
-p code {
+code:not([class]){
   border-radius: 4px;
   background-color: #ffefef;
 }
 
-// li code {
+// p code {
+//   border-radius: 4px;
+//   background-color: #ffefef;
+// }
+//
+// li code:not([class]) {
 //  border-radius: 4px;
 //  background-color: #ffefef;
 // }
+
 
 
 pre {
@@ -67,4 +73,8 @@ pre code:hover {
 
 pre code::-webkit-scrollbar-thumb:hover {
   background: $gray-200;
+}
+
+kbd {
+  background: #323435;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -132,7 +132,7 @@
           <li class="nav-item mx-2" role="presentation">
             <button class="nav-link" id="pills-macos-tab" data-bs-toggle="pill" data-bs-target="#pills-macos" type="button" role="tab" aria-controls="pills-macos" aria-selected="false">
               <svg class="d-block m-2 mx-auto" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="40" height="40"><title>Apple</title><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>
-              macOs
+              macOS
             </button>
           </li>
           <li class="nav-item mx-2" role="presentation">
@@ -155,7 +155,7 @@
           </div>
           <div class="tab-pane fade" id="pills-macos" role="tabpanel" aria-labelledby="pills-macos-tab">
             <h4 class="fs-6 version-text">Flameshot v0.10.1</h4>
-            <h5 class="fs-3 text-dark mx-2 my-0"><strong>macOs Downloads</strong></h5>
+            <h5 class="fs-3 text-dark mx-2 my-0"><strong>macOS Downloads</strong></h5>
             <p class="fs-6 text-dark mx-2 mt-2 mb-3">64-bit only, install via Homebrew or download the dmg file</p>
             <div class="col-12 my-4 mx-auto">
               <a class="btn btn-cta-solid btn-lg d-block d-md-inline-block m-2" href="https://formulae.brew.sh/cask/flameshot">Install via Homebrew</a>


### PR DESCRIPTION
The SCSS was improper and the html code tags that were inside `<li>` or `<ol>` was not detected to apply the background color and radius and now it works.

also all the instances of "macOs" were corrected to "macOS".