### PR TITLE
Fix typos and formatting

### DIFF
--- a/content/docs/guide/key-bindings.md
+++ b/content/docs/guide/key-bindings.md
@@ -15,27 +15,25 @@ top = false
 +++
 
 ## Local
-These shortcuts are available in GUI mode, meaning for example when you have ran `flameshot gui` command. In other words, these are the shortcuts that work *inside* the flameshot application:
+These shortcuts are available in GUI mode, meaning for example when you have ran `flameshot gui` command. In other words, these are the shortcuts that work *inside* the Flameshot application:
 
-|  Keys                                                                                         |  Description                         |
-|---                                                                                            |---                                   |
-| <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd>                                        | Move selection 1px                   |
-| <kbd>Shift</kbd> + <kbd><kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd></kbd>          | Resize selection 1px                 |
-| <kbd>Esc</kbd>                                                                                | Quit capture                         |
-| <kbd>Ctrl</kbd> + <kbd>C</kbd>                                                                | Copy to clipboard                    |
-| <kbd>Ctrl</kbd> + <kbd>S</kbd>                                                                | Save selection as a file             |
-| <kbd>Ctrl</kbd> + <kbd>Z</kbd>                                                                | Undo the last modification           |
-| Right Click                                                                                   | Show color picker                    |
-| Mouse Wheel (scroll)                                                                          | Change the tool's thickness          |
-
-<kbd>Shift</kbd> + drag a handler of the selection area: mirror re-dimension in the opposite handler.
+|  Keys                                                                                         |  Description                                  |
+|---                                                                                            |---                                            |
+| <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd>                                        | Move selection 1px                            |
+| <kbd>Shift</kbd> + <kbd><kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd></kbd>          | Resize selection 1px                          |
+| <kbd>Esc</kbd>                                                                                | Quit capture                                  |
+| <kbd>Ctrl</kbd> + <kbd>C</kbd>                                                                | Copy to clipboard                             |
+| <kbd>Ctrl</kbd> + <kbd>S</kbd>                                                                | Save selection as a file                      |
+| <kbd>Ctrl</kbd> + <kbd>Z</kbd>                                                                | Undo the last modification                    |
+| Right Click                                                                                   | Show color picker                             |
+| Mouse Wheel (scroll)                                                                          | Change the tool's thickness                   |
+| <kbd>Shift</kbd> + drag a handler of the selection area                                       | Mirror re-dimension in the opposite handler.  |
 
 You can change these default keybindings and more by opening the configuration, either by right-clicking on the tray icon or by running `flameshot config`, and navigating to **Shortcuts** tab:
 
 ![Flameshot configuration window and Shortcuts tab](/media/configuration_window/flameshot_config_shortcuts.png)
 
--------
--------
+--------------------------------------------------------------------------------
 
 ## Global Shortcuts for Operating Systems
 
@@ -47,13 +45,13 @@ By default you can start taking a screenshot using <kbd>Shift</kbd>+<kbd>CMD</kb
 
 ### Windows
 
-Typically in windows installations the <kbd>Prnt scr</kbd> should work out of the box.
+Typically in Windows installations the <kbd>Prnt Scr</kbd> should work out of the box.
 
 --------------------------------------------------------------------------------
 
 ### Linux
 
-If you want use Flameshot as a default screenshot utility, chances are you want to launch it using the <kbd>Prnt Scr</kbd> key. Flameshot doesn't yet offer a fully-automated option to do so, but you can configure your system to do so.
+If you want use Flameshot as a default screenshot utility, chances are you want to launch it using the <kbd>Prnt Scr</kbd> key. Flameshot doesn't yet offer a fully-automated option to do it, but you can configure your system to do so.
 
 #### On KDE Plasma desktop
 To make configuration easier, there's [a file](https://github.com/flameshot-org/flameshot/blob/master/docs/shortcuts-config/flameshot-shortcuts-kde.khotkeys) in the repository that more or less automates this process. This file will assign the following keys to the following actions by default:

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -21,23 +21,23 @@ Please first read the troubleshooting steps for your operating system in this pa
 
 To report a bug or suggest a new feature, you can go to [GitHub issues page](https://github.com/flameshot-org/flameshot/issues) and use the searchbox in the middle of the page to see if anyone else have already posted something similar. Sometimes you will find a quick solution just by reading the threads. In case of feature request, if you find someone with similar idea, just give that a thumbs-up to increase its priority/importance.
 
-In case you didn't find similar issue, create a new issue and explain in details what the issue is. If you can, add pictures or video recordings to clarify the situation. For bug reports, make sure to also visit the [issue reporting page](../issue-reporting) in which we have explained how to get the information we need in each bug report.
+In case you didn't find similar issue, create a new issue and explain in detail what the issue is. If you can, add pictures or video recordings to clarify the situation. For bug reports, make sure to also visit the [issue reporting page](../issue-reporting) in which we have explained how to get the information we need in each bug report.
 
 --------------------------------------------------------------------------------
 
 ## Linux
 
-### In the System tray area, flameshot appears to have duplicate icons/indicator
+### In the System tray area, Flameshot appears to have duplicate icons/indicator
 
-It is currently found in Ubuntu 14.04 and 16.04 Unity environment, such problems occur. This problem does not occur with Ubuntu 17.10 Unity. [#92](https://github.com/flameshot-org/flameshot/issues/92)
+It is currently known that in Ubuntu 14.04 and 16.04 Unity environments such problems occur. This problem does not occur with Ubuntu 17.10 Unity. [#92](https://github.com/flameshot-org/flameshot/issues/92)
 
-### In **Gnome** the flameshot icon does not appear in the tray
+### In **Gnome** the Flameshot icon does not appear in the tray
 
-* Gnome does not have a systray, therefore in Gnome you should install the gnome [Tray icons](https://extensions.gnome.org/extension/1503/tray-icons/) extension. For more information, read the [Tary icon](https://github.com/flameshot-org/flameshot#tray-icon) section of the github repository.
+Gnome does not have a systray, therefore in Gnome you should install the gnome [Tray icons](https://extensions.gnome.org/extension/1503/tray-icons/) extension. For more information, read the [Tray icon](https://github.com/flameshot-org/flameshot#tray-icon) section of the github repository.
 
 ### In **tiling window managers** (e.g i3wm, dwm, bspwm) Flameshot crashes when taking the screenshot
 
-* most tiling window managers dows not come with a nitification daemon, and Flameshot communicates with user through notifications. This means that Flameshot is dependent on notification manager to be installed and running. Easy way to test if you have a notification manager is to try `notify-send "test"` in your terminal. If you see the notification, you have it, otherwise we suggest you to install a notification manager such as `dunst`:
+Most tiling window managers dows not come with a notification daemon, and Flameshot communicates with user through notifications. This means that Flameshot is dependent on notification manager to be installed and running. Easy way to test if you have a notification manager is to try `notify-send "test"` in your terminal. If you see the notification, you have it, otherwise we suggest you to install a notification manager such as `dunst`:
 
 https://github.com/flameshot-org/flameshot/issues/1179#issuecomment-757544326
 
@@ -54,7 +54,7 @@ flameshot gui --region 300x200+300+300 --pin --accept-on-select
 
 ### In **tiling window managers** (e.g i3wm, dwm, bspwm) Flameshot only appears on a single monitor
 
-This can be because the window manager is forcing to tile FLameshot. This can be solved by defining window rule. For example for Sway the following rule is suggested in [#2364](https://github.com/flameshot-org/flameshot/issues/2364#issuecomment-1086129055):
+This can be because the window manager is forcing to tile Flameshot. This can be solved by defining window rule. For example for Sway the following rule is suggested in [#2364](https://github.com/flameshot-org/flameshot/issues/2364#issuecomment-1086129055):
 
 ```py
 for_window [app_id="flameshot"] border pixel 0, floating enable, fullscreen disable, move absolute position 0 0
@@ -64,7 +64,7 @@ for_window [app_id="flameshot"] border pixel 0, floating enable, fullscreen disa
 
 * First try the using the command `flameshot gui` in terminal. This does exactly what clicking on the tray icon does. (make sure can you see Flameshot icon in the tray area)
 
-* If the above step didn't work:
+* If the step above didn't work:
     1. Open 3 terminals
     2. Kill Flameshot if it is already open using `pkill flameshot`
     3. In the first terminal run `dbus-monitor --session sender=org.flameshot.Flameshot`
@@ -74,7 +74,7 @@ for_window [app_id="flameshot"] border pixel 0, floating enable, fullscreen disa
     - ![image](https://user-images.githubusercontent.com/390889/116671105-3b09d780-a9a9-11eb-8941-df52c9802c85.png)
     7. Post the link in the [issue on Github](https://github.com/flameshot-org/flameshot/issues)
 
-## In **Xfce** sometimes it doesn't let me to select area
+## In **Xfce** sometimes Flameshot does not let me select screenshot area
 
 It has been confirmed by multiple users that the compositor is at fault [#629](https://github.com/flameshot-org/flameshot/issues/629#issuecomment-989136575). It has been suggested to disable "Display fullscreen overlay windows directly". You just need to open "Window Manager Tweaks" in your Xfce, go to the "Compositor" tab and remove the checkmark from "Display fullscreen overlay windows directly".
 
@@ -88,7 +88,7 @@ As it has been reported multiple times already ([1](https://github.com/flameshot
 
 ![A picture of the macOS Security & Privacy settings that shows the Flameshot should be added to the list in the "privacy" tab](/media/macos_permissions.png)
 
-If you were still getting the following message when restarting Flameshot, try removing (using the "-" button) and then adding flameshot to the list above.
+If you were still getting the following message when restarting Flameshot, try removing (using the "-" button) and then adding Flameshot to the list above.
 
 ![A screenshot of a permission request window in macOS which says "Flameshot.app would like to record this computer's screen"](/media/macos_screenrecording_permission_request.png)
 
@@ -96,33 +96,34 @@ When this step is done you have to restart your macOS to make the permissions ge
 
 ### The command `flameshot` does not exist in my terminal
 
-- In general to have a command to your shell (e.g zsh) you should put the binary in your path. You can see your paths by `echo $PATH` (note that they are separated by `:`). You can either:
-                                                                                                                                1. create a symlink to flameshot binary in one of those folder listed (check out `man ln`)
-                                                                                                                                2. add the folder that contains Flameshot to your path (`export PATH="path/to/your/folder:$PATH"`). If you have installed Flameshot using the DMG we provide, Macports, or Homebrew, you most probably have it located in `/Applications/flameshot.app/`.
+In general to have a command to your shell (e.g zsh) you should put the binary in your path. You can see your paths by `echo $PATH` (note that they are separated by `:`). You can either:
+1. create a symlink to Flameshot binary in one of those folder listed (check out `man ln`)
+2. add the folder that contains Flameshot to your path (`export PATH="path/to/your/folder:$PATH"`). If you have installed Flameshot using the DMG we provide, Macports, or Homebrew, you most probably have it located in `/Applications/flameshot.app/`.
 
 ### Flameshot only works on the primary screen
 
-depending on how you have Spaces configured in Mission Control you may only be able to activate flameshot on a particular external display by using the `shift+alt+cmd+4` hotkey. Otherwise, flameshot will only activate on the main display if you click "Take Screenshot" from the application menu. Fix it by uninstalling, installing again and selecting flameshot again in the `Screen Recording` section. (reported to work [here](https://github.com/flameshot-org/flameshot/issues/1258#issuecomment-1004297496))
-                                                                                                                             --------------------------------------------------------------------------------
+Depending on how you have Spaces configured in Mission Control you may only be able to activate Flameshot on a particular external display by using the `shift+alt+cmd+4` hotkey. Otherwise, Flameshot will only activate on the main display if you click "Take Screenshot" from the application menu. Fix it by uninstalling, installing again and selecting Flameshot again in the `Screen Recording` section. (reported to work [here](https://github.com/flameshot-org/flameshot/issues/1258#issuecomment-1004297496))
+
+--------------------------------------------------------------------------------
 
 ## Windows
 
-### Commandline arguments does not work
+### Command line arguments does not work
 
-At the time of writing this (version 11.0.0), the commandline is not implemented for Windows. We might add it in future versions. You can follow the discussions/development of this feature in [#2118](https://github.com/flameshot-org/flameshot/issues/2118).
+At the time of writing this (version 11.0.0), the command line is not implemented for Windows. We might add it in future versions. You can follow the discussions/development of this feature in [#2118](https://github.com/flameshot-org/flameshot/issues/2118).
 
-In the meanshile you can use [AutoHotKey](https://www.autohotkey.com/) as [explained here](https://github.com/flameshot-org/flameshot/issues/1341#issuecomment-1126669379).
+In the meanwhile you can use [AutoHotKey](https://www.autohotkey.com/) as [explained here](https://github.com/flameshot-org/flameshot/issues/1341#issuecomment-1126669379).
 
 
-### Does not launch at startup even when the settings is set
+### Flameshot does not launch at startup even when the settings are set
 
 As [explained by @HoshyarKarimi](https://github.com/flameshot-org/flameshot/issues/2422#issuecomment-1140393544) (this should only be done once):
 
 
-1. From the configuration uncheck Launch at startup
+1. From the configuration uncheck "Launch at startup"
 2. Quit Flameshot from system tray
 3. Now run Flameshot _as administrator_
-4. Open the configuration and check the Launch at startup box
+4. Open the configuration and check the "Launch at startup" box
 
 The settings should now be set. You can close Flameshot from the system tray and use it normally from here after.
 

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -37,7 +37,7 @@ Gnome does not have a systray, therefore in Gnome you should install the gnome [
 
 ### In **tiling window managers** (e.g i3wm, dwm, bspwm) Flameshot crashes when taking the screenshot
 
-Most tiling window managers dows not come with a notification daemon, and Flameshot communicates with user through notifications. This means that Flameshot is dependent on notification manager to be installed and running. Easy way to test if you have a notification manager is to try `notify-send "test"` in your terminal. If you see the notification, you have it, otherwise we suggest you to install a notification manager such as `dunst`:
+Most tiling window managers do not come with a notification daemon, and Flameshot communicates with the user through notifications. This means that Flameshot is dependent on a notification manager to be installed and running. Easy way to test if you have a notification manager is to try `notify-send "test"` in your terminal. If you see the notification, you have it, otherwise we suggest you to install a notification manager such as `dunst`:
 
 https://github.com/flameshot-org/flameshot/issues/1179#issuecomment-757544326
 
@@ -62,7 +62,7 @@ for_window [app_id="flameshot"] border pixel 0, floating enable, fullscreen disa
 
 ### Flameshot icon is visible in tray area but when I click on it nothing happens
 
-* First try the using the command `flameshot gui` in terminal. This does exactly what clicking on the tray icon does. (make sure can you see Flameshot icon in the tray area)
+* First try the using the command `flameshot gui` in terminal. This does exactly what clicking on the tray icon does (make sure can you see Flameshot icon in the tray area).
 
 * If the step above didn't work:
     1. Open 3 terminals
@@ -96,8 +96,8 @@ When this step is done you have to restart your macOS to make the permissions ge
 
 ### The command `flameshot` does not exist in my terminal
 
-In general to have a command to your shell (e.g zsh) you should put the binary in your path. You can see your paths by `echo $PATH` (note that they are separated by `:`). You can either:
-1. create a symlink to Flameshot binary in one of those folder listed (check out `man ln`)
+In general to have a command in your shell (e.g zsh) you should put the binary in your path. You can see your paths by `echo $PATH` (note that they are separated by `:`). You can either:
+1. create a symlink to Flameshot binary in one of those folders listed (check out `man ln`)
 2. add the folder that contains Flameshot to your path (`export PATH="path/to/your/folder:$PATH"`). If you have installed Flameshot using the DMG we provide, Macports, or Homebrew, you most probably have it located in `/Applications/flameshot.app/`.
 
 ### Flameshot only works on the primary screen
@@ -108,7 +108,7 @@ Depending on how you have Spaces configured in Mission Control you may only be a
 
 ## Windows
 
-### Command line arguments does not work
+### Command line arguments do not work
 
 At the time of writing this (version 11.0.0), the command line is not implemented for Windows. We might add it in future versions. You can follow the discussions/development of this feature in [#2118](https://github.com/flameshot-org/flameshot/issues/2118).
 

--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -46,8 +46,8 @@ download a development version from [here](../development-build) or use AUR if y
 
 **Important things to Know:**
 
-1. Other than AUR (Arch user Repository) that is officially maintained by Flameshot developers, all packages listed above are maintained by the respective Linux distribution. Therefore, if the version is very old or you have problem installing Flameshot from the commands above, please directly contact the distribution.
-2. In rolling-release distros (e.g Arch, Solus), you can expect to get the recent version of Flameshot within the first few days of release, but in nonrolling-release distros (e.g Ubuntu, Debian, Fedora) you will most probably stay few version behind especially if your Linux release version is old (check [here](https://repology.org/metapackage/flameshot/versions)). In these cases you might want to either go for the packages we provide on [Flameshot release page](https://github.com/flameshot-org/flameshot/releases) or go with distro-agnostic solutions which are explained [here](#distro-agnostic).
+1. Other than AUR (Arch User Repository) that is officially maintained by Flameshot developers, all packages listed above are maintained by the respective Linux distribution. Therefore, if the version is very old or you have problems installing Flameshot from the commands above, please directly contact the distribution.
+2. In rolling-release distros (e.g Arch, Solus), you can expect to get the recent version of Flameshot within the first few days of release, but in nonrolling-release distros (e.g Ubuntu, Debian, Fedora) you will most probably stay a few versions behind, especially if your Linux release version is old (check [here](https://repology.org/metapackage/flameshot/versions)). In these cases you might want to either go for the packages we provide on [Flameshot release page](https://github.com/flameshot-org/flameshot/releases) or go with distro-agnostic solutions which are explained [here](#distro-agnostic).
 
 
 In addition, we also have continuous integration, it currently provides the following packages which can be accessed via our [Github release page](https://github.com/flameshot-org/flameshot/releases):
@@ -116,7 +116,7 @@ chmod +x Flameshot-*.x86_64.AppImage
 ./Flameshot-*.x86_64.AppImage
 ```
 
-This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). 
+This will create an icon in your system tray area (usually in the bottom-right ot top-right of the screen). 
 
 6. Now, you can launch the application. You can either:
 
@@ -127,7 +127,7 @@ This will create an icon in your system tray area. (usually in the bottom-right 
     ```sh
     ./Flameshot-*.x86_64.AppImage gui
     ```
-7. You may also add a symlink to the AppImage executable in your PATH. This way you can just run `flameshot` in your terminal and will automatically run the AppImage. For example:
+7. You may also add a symlink to the AppImage executable in your PATH. This way you can just run `flameshot` in your terminal and it will automatically run the AppImage. For example:
 
 ```sh
 ln --symbolic ~/Applications/Flameshot/Flameshot-11.0.0.x86_64.AppImage ~/.local/bin/flameshot

--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -96,13 +96,13 @@ rm Flameshot-*x86_64.AppImage
 
    3.2. Use the following to automatically download the latest.
 
-```sh
-curl --remote-name \
-     --remote-header-name \
-     --location $(curl -s https://api.github.com/repos/flameshot-org/flameshot/releases/latest \
-                | grep -Po 'https://github.com/flameshot-org/flameshot/releases/download/[^}]*\.AppImage' \
-                | uniq)
-```
+    ```sh
+    curl --remote-name \
+        --remote-header-name \
+        --location $(curl -s https://api.github.com/repos/flameshot-org/flameshot/releases/latest \
+                    | grep -Po 'https://github.com/flameshot-org/flameshot/releases/download/[^}]*\.AppImage' \
+                    | uniq)
+    ```
 
 4. Set it to executable:
 
@@ -116,16 +116,18 @@ chmod +x Flameshot-*.x86_64.AppImage
 ./Flameshot-*.x86_64.AppImage
 ```
 
-This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). You can now either:
+This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). 
 
-6.1. Click on the tray icon and select "Take screenshot"
+6. Now, you can launch the application. You can either:
 
-6.2. Open terminal and use the following to run the application:
+    6.1. Click on the tray icon and select "Take screenshot"
 
-```sh
-./Flameshot-*.x86_64.AppImage gui
-```
-You may also add a symlink to the AppImage executable in your PATH. This way you can just run `flameshot` in your terminal and will automatically run the AppImage. For example:
+    6.2. Open terminal and use the following to run the application:
+
+    ```sh
+    ./Flameshot-*.x86_64.AppImage gui
+    ```
+7. You may also add a symlink to the AppImage executable in your PATH. This way you can just run `flameshot` in your terminal and will automatically run the AppImage. For example:
 
 ```sh
 ln --symbolic ~/Applications/Flameshot/Flameshot-11.0.0.x86_64.AppImage ~/.local/bin/flameshot

--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -46,7 +46,7 @@ download a development version from [here](../development-build) or use AUR if y
 
 **Important things to Know:**
 
-1. Other than AUR (Arch user Repository) that is officially maintained by Flameshot developers, all packages listed above are maintained by the respective Linux distribution. Therefore, if the version is very old or you have problem installing Flameshot from the commands above, Please directly contact the distribution.
+1. Other than AUR (Arch user Repository) that is officially maintained by Flameshot developers, all packages listed above are maintained by the respective Linux distribution. Therefore, if the version is very old or you have problem installing Flameshot from the commands above, please directly contact the distribution.
 2. In rolling-release distros (e.g Arch, Solus), you can expect to get the recent version of Flameshot within the first few days of release, but in nonrolling-release distros (e.g Ubuntu, Debian, Fedora) you will most probably stay few version behind especially if your Linux release version is old (check [here](https://repology.org/metapackage/flameshot/versions)). In these cases you might want to either go for the packages we provide on [Flameshot release page](https://github.com/flameshot-org/flameshot/releases) or go with distro-agnostic solutions which are explained [here](#distro-agnostic).
 
 
@@ -59,10 +59,10 @@ In addition, we also have continuous integration, it currently provides the foll
 - Fedora32
 - OpenSUSE Leap 15.2
 
-General packages (AppImage, snap, and Flatpak): they can run on common Linux-based operating systems, such as RHEL, CentOS, openSUSE, SLED, Ubuntu, Fedora, debian and derivatives.
+General packages (AppImage, snap, and Flatpak): they can run on common Linux-based operating systems, such as RHEL, CentOS, openSUSE, SLED, Ubuntu, Fedora, Debian and derivatives.
 
 <details>
-  <summary>Expand this section to see what distros are using an up to date version of flameshot</summary>
+  <summary>Expand this section to see what distros are using an up to date version of Flameshot</summary>
   <a href="https://repology.org/metapackage/flameshot/versions">
     <img src="https://repology.org/badge/vertical-allrepos/flameshot.svg" alt="Packaging status">
   </a>
@@ -91,9 +91,10 @@ rm Flameshot-*x86_64.AppImage
 ```
 
 3. Download the latest AppImage
-   2.1. Get it from [Release page](https://github.com/flameshot-org/flameshot/releases/latest)
-   OR
-   2.2. use the following to automatically download the latest.
+
+   3.1. Get it from [Release page](https://github.com/flameshot-org/flameshot/releases/latest), OR
+
+   3.2. Use the following to automatically download the latest.
 
 ```sh
 curl --remote-name \
@@ -117,9 +118,9 @@ chmod +x Flameshot-*.x86_64.AppImage
 
 This will create an icon in your system tray area. (usually in the bottom-right ot top-right of the screen). You can now either:
 
-6.1 click on the tray icon and select "Take screenshot"
+6.1. Click on the tray icon and select "Take screenshot"
 
-6.2 open terminal and use the following to run the application:
+6.2. Open terminal and use the following to run the application:
 
 ```sh
 ./Flameshot-*.x86_64.AppImage gui
@@ -141,7 +142,7 @@ Flameshot is not currently on snap, but when it gets available, you can install 
 snap install flameshot
 ```
 
-to update the snap applications on your computer, you should run `snap refresh`.
+To update the snap applications on your computer, you should run `snap refresh`.
 
 
 ### Flatpak  <img src="https://img.shields.io/flathub/downloads/org.flameshot.Flameshot">
@@ -158,7 +159,7 @@ Alternatively you can install from the github using Flatpak if you want a specif
 flatpak install https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/org.flameshot.Flameshot-0.9.0.x86_64.flatpak
 ```
 
-And for runing it you should do
+And for running it you should do
 
 ```sh
 flatpak run org.flameshot.Flameshot
@@ -177,7 +178,7 @@ This can help when creating custom keyboard shortcuts.
 
 ### Docker  <img src="https://img.shields.io/docker/pulls/manuellr/flameshot">  <img src="https://img.shields.io/docker/image-size/manuellr/flameshot?sort=date">
 
-There is also a docker image available for those who want (**not** maintained by Flameshot maintainers):
+There is also a docker image available for those who want it (**not** maintained by Flameshot maintainers):
 
 <https://github.com/ManuelLR/docker-flameshot>
 

--- a/content/docs/installation/installation-linux.md
+++ b/content/docs/installation/installation-linux.md
@@ -116,7 +116,7 @@ chmod +x Flameshot-*.x86_64.AppImage
 ./Flameshot-*.x86_64.AppImage
 ```
 
-This will create an icon in your system tray area (usually in the bottom-right ot top-right of the screen). 
+This will create an icon in your system tray area (usually in the bottom-right or top-right of the screen). 
 
 6. Now, you can launch the application. You can either:
 

--- a/content/docs/installation/source-code.md
+++ b/content/docs/installation/source-code.md
@@ -90,17 +90,17 @@ pacman -S xdg-desktop-portal xdg-desktop-portal-wlr grim
 
 ## Getting the Source Code
 
-You can get the gource code from [our Github repository](https://github.com/flameshot-org/flameshot). Either clone the repository or download a ZIP file. We suggest downloading the ZIP file if you want to build on specific version, but if you want to build different commits and versions, using `git` makes it much easier.
+You can get the source code from [our Github repository](https://github.com/flameshot-org/flameshot). Either clone the repository or download a ZIP file. We suggest downloading the ZIP file if you want to build on specific version, but if you want to build different commits and versions, using `git` makes it much easier.
 Please note that in this page we explain how to download the [master branch](https://github.com/flameshot-org/flameshot/tree/master), but you can get the source code for every [Pull Request](https://github.com/flameshot-org/flameshot/pulls) and compile them if you like to.
 
-In general we suggest you to create a temprory directory to download the file and do compiling there:
+In general we suggest you to create a temporary directory to download the file and do the compiling there:
 
 ```sh
 # create the folder
-mkdir --parents ~/tmp/flamshot_source/
+mkdir --parents ~/tmp/flameshot_source/
 
 # go inside the new foldr
-cd ~/tmp/flamshot_source/
+cd ~/tmp/flameshot_source/
 ```
 
 To download [the ZIP file from the master branch](https://github.com/flameshot-org/flameshot/archive/refs/heads/master.zip) you can run:


### PR DESCRIPTION
This is mostly typos and grammar mistakes, although I also took the liberty of changing the format of two pages to make them more consistent overall.

- In `key-bindings` I simply fixed the shortcuts table.

- In `installation-linux.md` I changed the format of Distro-Agnostic AppImage steps to make it more readable.
