### PR TITLE
Update head.html to only include article:publisher and article:author if the respective variable is set

### DIFF
--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -102,8 +102,12 @@
       <meta property="og:video" content="{{ get_url(path=video) }}">
     {% endfor %}
   {% endif %}
-  <meta property="article:publisher" content="https://www.facebook.com/{{ config.extra.open.facebook_publisher }}">
-  <meta property="article:author" content="https://www.facebook.com/{{ config.extra.open.facebook_author }}">
+  {% if config.extra.open.facebook_publisher %}
+    <meta property="article:publisher" content="https://www.facebook.com/{{ config.extra.open.facebook_publisher }}">
+  {% endif %}
+  {% if config.extra.open.facebook_author %}
+    <meta property="article:author" content="https://www.facebook.com/{{ config.extra.open.facebook_author }}">
+  {% endif %}
   <meta property="og:locale" content="{{ config.extra.open.og_locale }}">
 {% endif %}
 


### PR DESCRIPTION
This happens in the homepage.

![image](https://user-images.githubusercontent.com/2728038/183071091-220093c7-1667-47fb-9ec5-1fbc79af6725.png)


You probably don't want Facebook to be marked as your author :) 

Since other metadata is missing (like meta description) this is sometimes used in SEO previews. See for example in Telegram

![image](https://user-images.githubusercontent.com/2728038/183071336-3354a5e9-973a-4699-8ac5-2e387d90084b.png)
