### PR TITLE
Set HTML metadata description to some sensible value

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 # The URL the site will be built for
 base_url = "https://flameshot.org/"
 title = "Flameshot"
-description = ""
+description = "Flameshot is a free and open-source, cross-platform tool to take screenshots with many built-in features to save you time."
 
 # The default language; used in feeds and search index
 # Note: the search index doesn't support Chinese/Japanese/Korean Languages


### PR DESCRIPTION
Currently this is empty 
![image](https://user-images.githubusercontent.com/2728038/183071723-a361ac6c-5d82-4362-a992-d471e7b3a09c.png)


This will cause search engines to pull this value from the page, leading to some unwanted description to be shown. See the attached screenshot for example:

![image](https://user-images.githubusercontent.com/2728038/183071830-ff492740-704e-4ec2-ae0d-14014ac0b22d.png)
