### PR TITLE
style(header): remove toggle theme button outline on focus

### DIFF
--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -4,7 +4,7 @@
 		<input class="menu-btn order-0" type="checkbox" id="menu-btn">
 		<label class="menu-icon d-lg-none" for="menu-btn"><span class="navicon"></span></label>
 		<a class="navbar-brand order-1 order-lg-0 me-auto text-purple" href="{{ config.base_url | safe }}"><img class="d-inline-block my-auto mr-2" src="{{ get_url(path='flameshot-icon.svg') }}" alt="logo" width="32" height="32"> {{ config.title | default(value="Flameshot") }}</a>
-		<button id="mode" class="btn btn-link order-2 order-lg-4" type="button" aria-label="Toggle mode">
+		<button id="mode" class="btn p-0 order-2 order-lg-4" type="button" aria-label="Toggle mode">
 			<span class="toggle-dark"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></span>
 			<span class="toggle-light"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-sun"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg></span>
 		</button>


### PR DESCRIPTION
The toggle theme button on the header of the page has an outline on the user's focus. I have removed the `btn-link` class and handled the padding using `tailwindCSS` hence the outline has been removed.