### PR TITLE
Add developer docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,23 @@ on:
   pull_request:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v3.0.0
+      - name: Build only
+        uses: shalzz/zola-deploy-action@v0.16.1
+        env:
+          BUILD_DIR: .
+          BUILD_ONLY: true
+          BUILD_FLAGS: --drafts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_and_deploy:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout master
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           git config user.email "github-actions-bot@users.noreply.github.com"
 
           git fetch origin gh-pages:gh-pages developer-docs:developer-docs
-          git log --all
+          git checkout gh-pages
           git cherry-pick developer-docs || true
           git remote add destination "https://${{github.actor}}:${{github.token}}@github.com/${{github.repository}}.git"
           git push destination gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v3.0.0
       - name: Build only
-        uses: shalzz/zola-deploy-action@v0.16.1
+        uses: shalzz/zola-deploy-action@v0.16.1-1
         env:
           BUILD_DIR: .
           BUILD_ONLY: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev-docs
   pull_request:
 
 jobs:
@@ -40,6 +41,7 @@ jobs:
           git config user.email "github-actions-bot@users.noreply.github.com"
 
           git fetch origin gh-pages:gh-pages developer-docs:developer-docs
+          git log --all
           git cherry-pick developer-docs || true
           git remote add destination "https://${{github.actor}}:${{github.token}}@github.com/${{github.repository}}.git"
           git push destination gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,23 +8,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v3.0.0
-      - name: Build only
-        uses: shalzz/zola-deploy-action@v0.16.1
-        env:
-          BUILD_DIR: .
-          BUILD_ONLY: true
-          BUILD_FLAGS: --drafts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build_and_deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout master
         uses: actions/checkout@v3.0.0

--- a/templates/docs/section.html
+++ b/templates/docs/section.html
@@ -10,6 +10,14 @@
   {{ macros_header::header(current_section=current_section)}}
 {% endblock header %}
 
+{% macro page_card(permalink, title) %}
+  <div class="card my-3">
+    <div class="card-body">
+      <a class="stretched-link" href="{{ permalink }}">{{ title }} &rarr;</a>
+    </div>
+  </div>
+{% endmacro page_card %}
+
 {% block content %}
 <div class="wrap container" role="document">
   <div class="content">
@@ -22,24 +30,18 @@
             {% set index_path = current_path ~ "_index.md" | trim_start_matches(pat="/") %}
             {% set index = get_section(path=index_path) %}
             {% for page in index.pages %}
-              <div class="card my-3">
-                <div class="card-body">
-                  <a class="stretched-link" href="{{ page.permalink }}">{{ page.title }} &rarr;</a>
-                </div>
-              </div>
+              {{ self::page_card(permalink=page.permalink, title=page.title) }}
             {% endfor %}
             {% for s in index.subsections %}
               {% set subsection = get_section(path=s) %}
               {% if subsection.pages %}
                 {% for page in subsection.pages %}
-                <div class="card my-3">
-                  <div class="card-body">
-                    <a class="stretched-link" href="{{ page.permalink }}">{{ page.title }} &rarr;</a>
-                  </div>
-                </div>
-                {% endfor %}                                    
+                  {{ self::page_card(permalink=page.permalink, title=page.title) }}
+                {% endfor %}
               {% endif %}
             {% endfor %}
+            {# TODO maybe there is a better way to do this. #}
+            {{ self::page_card(permalink="/docs/dev", title="Developer Docs") }}
           </div>
         </article>
       </div>


### PR DESCRIPTION
Adds support for developer docs. The developer docs are maintained on the main flameshot repo, but they need to be deployed with a workflow here.

This PR adds a reference to the documentation in the Docs section and a workflow that will re-apply the developer docs during the build_and_deploy job.

In order to add a reference to the developer docs in the Docs section, I edited the `templates/docs/section.html` template to hardcode the section there, because that's the only way I know how. Is that OK? If you know of a better way, please tell me.
