### PR TITLE
Uppercase `h` in GitHub

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -220,7 +220,7 @@
       <div class="d-block d-lg-flex text-center col-lg-12 col-xl-10 mx-auto">
         <div class="p-2 d-block d-lg-flex flex-fill align-self-center align-items-center">
           <img class="d-block d-lg-inline-block mx-auto mx-lg-0" src="flameshot-icon.svg" alt="logo" width="50" height="50">
-          <h5 class="text-purple fs-3 fw-bold d-block d-lg-inline-block mx-auto mx-lg-0 ms-0 ms-lg-3 my-4 my-lg-0">Contribute to Flameshot on Github</h5>
+          <h5 class="text-purple fs-3 fw-bold d-block d-lg-inline-block mx-auto mx-lg-0 ms-0 ms-lg-3 my-4 my-lg-0">Contribute to Flameshot on GitHub</h5>
         </div>
         <div class="d-block justify-content-end p-2 justify-content-center">
           <a class="btn btn-cta-solid btn-lg mx-auto mx-lg-0" href="https://github.com/flameshot-org/flameshot">Contribute</a>


### PR DESCRIPTION
Noticed and fixed a teeny typo. 

![](https://i.gifer.com/origin/7d/7d40f6b7e846bf2153a96b4e5ce2132e.gif)