### PR TITLE
Fix a few typos and wording consistency issues in the CLI documentation

### DIFF
--- a/content/docs/advanced/commandline-options.md
+++ b/content/docs/advanced/commandline-options.md
@@ -78,10 +78,10 @@ Check out the information window to see all the available shortcuts in the graph
 In Flameshot (version 11.0.0 or later) we now have the concept of "final actions". These are things you would like to do after you have done with annotating your screenshot. The final actions are:
 
 - `--path <path>`: Where the screenshot should be stored (can be path to the folder or the file)
-- `--clipboard`: Whether the screenshot should be copied to cliboard
-- `--raw`: Sending the screeenshot to stdout
-- `--upload`: Uploading the screenshot
-- `--pin`: Pinning the screenshot
+- `--clipboard`: Whether the screenshot should be copied to the clipboard
+- `--raw`: Send the screenshot to stdout
+- `--upload`: Upload the screenshot
+- `--pin`: Pin the screenshot
 - `--print-geometry`: Write the position and dimension of the screenshot to stdout
 
 The benefit of having the concept of Final Actions is that you can use more than one of them at the same time. For instance you can pin, copy to clipboard, save to a file, and get the geometry of the screenshot using this:


### PR DESCRIPTION
Hi, I noticed a few typos that I thought I could help by fixing.