### PR TITLE
Update hyperlinks on Overview page

### DIFF
--- a/content/docs/overview/overview.md
+++ b/content/docs/overview/overview.md
@@ -28,13 +28,13 @@ top = false
 - Experimentally **Gnome Wayland** and **Plasma Wayland** support.
 - If you are using Gnome you need to install the [TopIcons](https://extensions.gnome.org/extension/1031/topicons/) extension in order to see the systemtray icon.
 - In order to speed up the first launch of Flameshot (DBus init of the app can be slow), consider starting the application automatically on boot.
-- Press <kbd>Ctrl</kbd>+<kbd>c</kbd> when you are in a capture mode and you don't have an active selection and the whole desktop will be copied to your clipboard! Pressing <kbd>Ctrl</kbd>+<kbd>s</kbd> will save your capture in a file! Check the [Shortcuts](/guide/key-bindings/#keyboard-shortcuts) for more information.
+- Press <kbd>Ctrl</kbd>+<kbd>c</kbd> when you are in a capture mode and you don't have an active selection and the whole desktop will be copied to your clipboard! Pressing <kbd>Ctrl</kbd>+<kbd>s</kbd> will save your capture in a file! Check the [Shortcuts](/docs/guide/key-bindings/) for more information.
 - Execute the command `flameshot` without parameters or use the "Launch Flameshot" desktop entry to launch a running instance of the program without taking actions.
 
 ## License
 
-- The main code is licensed under [GPLv3](https://github.com/flameshot-org/flameshot/LICENSE)
-- The logo of Flameshot is licensed under [Free Art License v1.3](https://github.com/flameshot-org/flameshot/img/flameshotLogoLicense.txt)
+- The main code is licensed under [GPLv3](https://github.com/flameshot-org/flameshot/blob/master/LICENSE)
+- The logo of Flameshot is licensed under [Free Art License v1.3](https://github.com/flameshot-org/flameshot/blob/master/data/img/app/flameshotLogoLicense.txt)
 - The button icons are licensed under Apache License 2.0. See: <https://github.com/google/material-design-icons>
 - The code at `capture/capturewidget.cpp` is based on <https://github.com/ckaiser/Lightscreen/blob/master/dialogs/areadialog.cpp> (GPLv2)
 - The code at `capture/capturewidget.h` is based on <https://github.com/ckaiser/Lightscreen/blob/master/dialogs/areadialog.h> (GPLv2)


### PR DESCRIPTION
Updates hyperlinks on https://flameshot.org/docs/overview/overview that currently point to 404s.