### PR TITLE
CI - Fix zola-deploy action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev-docs
+      - dev-docs-staging
   pull_request:
 
 jobs:
@@ -40,8 +41,8 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "github-actions-bot@users.noreply.github.com"
 
-          git fetch origin gh-pages:gh-pages developer-docs:developer-docs
+          git fetch origin gh-pages:gh-pages dev-docs-staging:dev-docs-staging
           git checkout gh-pages
-          git cherry-pick developer-docs || true
+          git cherry-pick dev-docs-staging || true
           git remote add destination "https://${{github.actor}}:${{github.token}}@github.com/${{github.repository}}.git"
           git push destination gh-pages


### PR DESCRIPTION
Hi :wave: 

From what I can tell, the `developer-docs` branch was renamed to `dev-docs-staging` around the time of this commit: https://github.com/flameshot-org/flameshot-org.github.io/commit/14ae19351a1646fa1e71c1d366afda6cefa4b42c

This PR will make CI pass :partying_face: 