### PR TITLE
Update config.toml parameter to suit the latest version of zola

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ default_language = "en"
 compile_sass = true
 
 # Whether to generate a feed file for the site
-generate_feed = true
+generate_feeds = true
 
 # When set to "true", the generated HTML files are minified.
 minify_html = false


### PR DESCRIPTION
I encountered an error when i tried to install this locally on my Win11 pc with `zola 0.20.0`

Error:
```
Building site...
Error: Failed to serve the site
Error: TOML parse error at line 14, column 1
   |
14 | generate_feed = true
   | ^^^^^^^^^^^^^
unknown field `generate_feed`, expected one of `base_url`, `theme`, `title`, `description`, `default_language`, `languages`, `translations`, `generate_feeds`, `feed_limit`, `feed_filenames`, `hard_link_static`, `taxonomies`, `author`, `compile_sass`, `minify_html`, `build_search_index`, `ignored_content`, `ignored_static`, `mode`, `output_dir`, `preserve_dotfiles_in_output`, `link_checker`, `slugify`, `search`, `markdown`, `extra`, `generate_sitemap`, `generate_robots_txt`, `exclude_paginated_pages_in_sitemap`
```

Fix:

The following change to suit the latest made it work:
**`generate_feed`** → **`generate_feeds`**