### PR TITLE
Improved footer macro to update with current year

### DIFF
--- a/templates/macros/footer.html
+++ b/templates/macros/footer.html
@@ -31,7 +31,7 @@
         <a rel="me" class="d-inline-block m-1" href="https://fosstodon.org/@flameshot"><img class="footer-icon" src="{{ get_url(path='img/icons/mastodon.svg') }}" alt="mastodon logo." width="26" height="26"></a>
         <a class="d-inline-block m-1" href="https://matrix.to/#/#flameshot-org:matrix.org"><img class="footer-icon" src="{{ get_url(path='img/icons/matrix.svg') }}" alt="matrix logo." width="26" height="26"></a>
       </div>
-      <small class="text-white mt-3">Copyright &copy; 2017-2024 Flameshot contributors &bullet; Site design by <a class="cs-link" href="https://github.com/Correct-Syntax">Correct Syntax</a></small>
+      <small class="text-white mt-3">Copyright &copy; 2017-{{ now() | date(format="%Y") }} Flameshot contributors &bullet; Site design by <a class="cs-link" href="https://github.com/Correct-Syntax">Correct Syntax</a></small>
     </div>
 </footer>
 {% endmacro %}


### PR DESCRIPTION
This is a PR to address #170

The fix now does fetch the current time like YYYY-MM-DDTHH:MM:SS+00:00 and only use YYYY of it  in the footer.

New Footer will look like:
```
Copyright © 2017-YYYY Flameshot contributors 
```


- [x]  I've tested it locally by building it too.
<img src="https://github.com/user-attachments/assets/6681cba2-81ba-4659-a724-39f5b0f15fa2" width="300">

