### PR TITLE
remove imgur from index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -96,20 +96,11 @@
     </div>
     <div class="row justify-content-center mb-3 py-3 mx-auto">
       <div class="col-12 col-lg-5 px-0">
-        <img class="img-fluid box-shadow mh-100" src="img/upload-to-online-platforms.jpg" loading="lazy" alt="upload to online platforms">
+        <img class="img-fluid box-shadow mh-100" src="img/cli.jpg" loading="lazy" alt="command line interface">
       </div>
       <div class="col-12 col-lg-7 my-auto ps-lg-5 px-0">
-        <h5 class="text-purple fw-bold fs-4">Upload to online platforms</h5>
-        <p class="text-dark">Flameshot allows users to simply upload their screenshots directly to the cloud in order to easily share it with others. You can upload your image directly to <a href="https://imgur.com/">Imgur</a> with a single click and share the URL with others. </p>
-      </div>
-    </div>
-    <div class="row justify-content-center mb-3 py-3 mx-auto">
-      <div class="col-12 col-lg-7 my-auto pe-lg-5 px-0">
         <h5 class="text-purple fw-bold fs-4">Command-line interface (CLI)</h5>
         <p class="text-dark">Flameshot has several commands you can use in the terminal without launching the GUI via a command line interface. The command line interface lets you script Flameshot and use it as the subject of key binds.</p>
-      </div>
-      <div class="col-12 col-lg-5 px-0">
-        <img class="img-fluid box-shadow mh-100" src="img/cli.jpg" loading="lazy" alt="command line interface">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Since the following commit in the main repo, the imgur is not by default part of Flameshot and is optionally compiled:

https://github.com/flameshot-org/flameshot/pull/4034

So here I removed the upload feature from the index page while keeping the https://flameshot.org/docs/guide/imgur-help/